### PR TITLE
`[feat/statusline-integration]` fix rendering and add session duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/test-statusline.sh` — `run_scenario` now handles stdin-mode scenarios (presence of `stdin.json` in the scenario dir); COLUMNS is passed explicitly in env args for both code paths (#35)
 - `dotfiles/install.sh` — claude-status hook wiring updated to register `SessionStart`, `UserPromptSubmit`, `Notification`, `Stop`, `SessionEnd` (replaces `PreToolUse`/`PostToolUse`/`SubagentStop`); sets `statusLine.command` to our `scripts/statusline.sh` when claude-status is present
 
+### Changed
+- `hooks/claude-hook.sh` — `SessionStart` now records `session_start_epoch`; `UserPromptSubmit` no longer deletes `duration_seconds` (#35)
+- `scripts/statusline.sh` — duration component now shows total session time (`now - session_start_epoch`), computed live on each render so it never disappears mid-session; supports `MOCK_NOW` env var for deterministic tests (#35)
+- `tests/test-statusline.sh` — exports `MOCK_NOW=1772340000` so duration is stable across runs (#35)
+- `tests/data/*/state.json` — replaced `duration_seconds` with `session_start_epoch` derived from `MOCK_NOW - duration` (#35)
+
 ### Fixed
 - `hooks/claude-hook.sh` — Stop hook exiting non-zero (silent crash) when no long-running notification fired: `$fired && log_info` expanded `false` as a command (exit 1), triggering `set -e`; replaced with `[[ "$fired" == "true" ]] && ... || true`
 - `scripts/statusline.sh` — terminal width now read via `stty size </dev/tty` (TIOCGWINSZ) instead of `tput cols` which always returned 80 when stdin was a pipe; falls back to 120 (#35)

--- a/hooks/claude-hook.sh
+++ b/hooks/claude-hook.sh
@@ -110,6 +110,9 @@ handle_session_start() {
   source=$(printf '%s' "$HOOK_INPUT" | jq -r '.source // empty')
   model=$(printf '%s'  "$HOOK_INPUT" | jq -r '.model  // empty')
 
+  local now
+  now=$(date +%s)
+
   _git_info "$CWD"
 
   local new_state
@@ -121,15 +124,17 @@ handle_session_start() {
     --argjson git_modified "$GIT_MODIFIED" \
     --arg source        "$source" \
     --arg model         "$model" \
+    --argjson epoch     "$now" \
     '{
-      session_id:   $session_id,
-      state:        "ready",
-      directory:    $directory,
-      branch:       $branch,
-      git_staged:   $git_staged,
-      git_modified: $git_modified,
-      source:       $source,
-      model:        $model
+      session_id:          $session_id,
+      state:               "ready",
+      directory:           $directory,
+      branch:              $branch,
+      git_staged:          $git_staged,
+      git_modified:        $git_modified,
+      source:              $source,
+      model:               $model,
+      session_start_epoch: $epoch
     }')
 
   write_state "$SESSION_ID" "$new_state"
@@ -162,8 +167,7 @@ handle_user_prompt_submit() {
       | .branch             = $branch
       | .git_staged         = $staged
       | .git_modified       = $modified
-      | .prompt_start_epoch = $epoch
-      | del(.duration_seconds)')
+      | .prompt_start_epoch = $epoch')
 
   write_state "$SESSION_ID" "$updated"
   log_info "UserPromptSubmit state→working"

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -131,7 +131,9 @@ GIT_STAGED="$( _field git_staged)"
 GIT_MOD="$(    _field git_modified)"
 CONTEXT_PCT="$(_field context_pct)"
 COST_USD="$(   _field cost_usd)"
-DURATION="$(   _field duration_seconds)"
+SESSION_START="$(_field session_start_epoch)"
+DURATION=""
+[[ -n "$SESSION_START" ]] && DURATION=$(( ${MOCK_NOW:-$(date +%s)} - SESSION_START ))
 
 # In statusLine mode, fresh stdin values are authoritative (STATE_FILE may
 # not have been patched yet if the file appeared between the patch and read)

--- a/tests/data/high-context/state.json
+++ b/tests/data/high-context/state.json
@@ -7,8 +7,8 @@
   "git_modified": 5,
   "context_pct": 91,
   "cost_usd": 1.24,
-  "duration_seconds": 183,
   "prompt_start_epoch": 1700000500,
   "last_tool_name": "Write",
-  "last_tool_exit_code": 0
+  "last_tool_exit_code": 0,
+  "session_start_epoch": 1772339817
 }

--- a/tests/data/long-running/state.json
+++ b/tests/data/long-running/state.json
@@ -7,6 +7,6 @@
   "git_modified": 0,
   "context_pct": 78,
   "cost_usd": 4.82,
-  "duration_seconds": 5483,
-  "prompt_start_epoch": 1700010000
+  "prompt_start_epoch": 1700010000,
+  "session_start_epoch": 1772334517
 }

--- a/tests/data/no-statusline/state.json
+++ b/tests/data/no-statusline/state.json
@@ -7,8 +7,8 @@
   "git_modified": 0,
   "context_pct": 10,
   "cost_usd": 0.005,
-  "duration_seconds": 2,
   "prompt_start_epoch": 1700000600,
   "last_tool_name": null,
-  "last_tool_exit_code": null
+  "last_tool_exit_code": null,
+  "session_start_epoch": 1772339998
 }

--- a/tests/data/ready-changes/state.json
+++ b/tests/data/ready-changes/state.json
@@ -7,8 +7,8 @@
   "git_modified": 2,
   "context_pct": 61,
   "cost_usd": 0.087,
-  "duration_seconds": 28,
   "prompt_start_epoch": 1700000200,
   "last_tool_name": "Edit",
-  "last_tool_exit_code": 0
+  "last_tool_exit_code": 0,
+  "session_start_epoch": 1772339972
 }

--- a/tests/data/ready/state.json
+++ b/tests/data/ready/state.json
@@ -7,8 +7,8 @@
   "git_modified": 0,
   "context_pct": 18,
   "cost_usd": 0.011,
-  "duration_seconds": 4,
   "prompt_start_epoch": 1700000100,
   "last_tool_name": "Read",
-  "last_tool_exit_code": 0
+  "last_tool_exit_code": 0,
+  "session_start_epoch": 1772339996
 }

--- a/tests/data/stdin-mode/state.json
+++ b/tests/data/stdin-mode/state.json
@@ -5,5 +5,6 @@
   "branch": "feat/35-statusline-integration",
   "git_staged": 1,
   "git_modified": 2,
-  "prompt_start_epoch": 1700000000
+  "prompt_start_epoch": 1700000000,
+  "session_start_epoch": 1772339970
 }

--- a/tests/data/working/state.json
+++ b/tests/data/working/state.json
@@ -7,8 +7,8 @@
   "git_modified": 1,
   "context_pct": 42,
   "cost_usd": 0.042,
-  "duration_seconds": 12,
   "prompt_start_epoch": 1700000000,
   "last_tool_name": "Bash",
-  "last_tool_exit_code": null
+  "last_tool_exit_code": null,
+  "session_start_epoch": 1772339988
 }

--- a/tests/test-statusline.sh
+++ b/tests/test-statusline.sh
@@ -26,6 +26,9 @@ source "$REPO_DIR/scripts/common.sh"
 # The statusline script reads COLUMNS (falls back to tput cols).
 export COLUMNS="${STATUSLINE_WIDTH:-120}"
 
+# Fix "now" so duration (now - session_start_epoch) is deterministic across runs.
+export MOCK_NOW=1772340000
+
 # ── Guard ─────────────────────────────────────────────────────────────────────
 if [[ ! -f "$STATUSLINE" ]]; then
     err "scripts/statusline.sh not yet implemented"


### PR DESCRIPTION
## Summary

- Right-side content (context bar, cost, duration) was not visible due to terminal width always resolving to 80 when stdin is a pipe; fixed with `stty size </dev/tty` (TIOCGWINSZ)
- Wide emoji (📁 🌿 💰) were under-counted as 1 column; fixed with F0–F4 byte detection in `_visible_len`
- Duration now shows total session age (`now - session_start_epoch`), computed live on each render — never disappears mid-session
- `SessionStart` records `session_start_epoch`; `UserPromptSubmit` no longer clears duration

## Test plan
- [x] `bash scripts/run-tests.sh` passes (22 passed, 0 failed)
- [x] Right-side content visible and right-aligned in live Claude session
- [x] Duration shows and increments; persists across prompt submissions

Closes #35